### PR TITLE
Adds compensation of angle error over frequency to non conventional

### DIFF
--- a/tests/test_anglecmpoverfrequency/test_anglecmpoverfrequency.cpp
+++ b/tests/test_anglecmpoverfrequency/test_anglecmpoverfrequency.cpp
@@ -1,0 +1,55 @@
+#include "test_anglecmpoverfrequency.h"
+
+void test_anglecmpoverfrequency::test_getcompValue()
+{
+    double val;
+    angleCmpOverFrequency test;
+    val = test.getCompValue(80,50);
+    QCOMPARE( qFuzzyCompare(val,static_cast<double>(0.656/180*M_PI)), true);
+    val = test.getCompValue(80,60);
+    QCOMPARE( qFuzzyCompare(val,static_cast<double>(0.546/180*M_PI)), true);
+    val = test.getCompValue(256,50);
+    QCOMPARE( qFuzzyCompare(val,static_cast<double>(0.789/180*M_PI)), true);
+    val = test.getCompValue(256,60);
+    QCOMPARE( qFuzzyCompare(val,static_cast<double>(0.649/180*M_PI)), true);
+    val = test.getCompValue(96,50);
+    QCOMPARE( qFuzzyCompare(val,static_cast<double>(0.0)), true);
+
+}
+
+void test_anglecmpoverfrequency::test_frequencyRange()
+{
+    bool ok;
+    angleCmpOverFrequency test;
+    ok = test.isFreuqencyInRange(12.0);
+    QCOMPARE( ok, false);
+    ok = test.isFreuqencyInRange(66.0);
+    QCOMPARE( ok, false);
+    ok = test.isFreuqencyInRange(45.0);
+    QCOMPARE( ok, true);
+    ok = test.isFreuqencyInRange(55.0);
+    QCOMPARE( ok, true);
+}
+
+void test_anglecmpoverfrequency::test_angleCorrection()
+{
+    double val;
+    angleCmpOverFrequency test;
+    test.getCompValue(80,50);
+    val = test.correctAngle(1.0,50.1,50);
+    QCOMPARE( qFuzzyCompare(val,static_cast<double>(1.0+(0.1*0.656/180*M_PI))), true);
+
+    test.getCompValue(80,60);
+    val = test.correctAngle(-1.0,55.0,60.0);
+    QCOMPARE( qFuzzyCompare(val,static_cast<double>(-1.0+(-5.0*0.546/180*M_PI))), true);
+
+    test.getCompValue(256,50);
+    val = test.correctAngle(1.0,55.0,50);
+    QCOMPARE( qFuzzyCompare(val,static_cast<double>(1.0+(5.0*0.789/180*M_PI))), true);
+
+    test.getCompValue(256,60);
+    val = test.correctAngle(-1.0,55.0,60.0);
+    QCOMPARE( qFuzzyCompare(val,static_cast<double>(-1.0+(-5.0*0.649/180*M_PI))), true);
+}
+
+QTEST_MAIN(test_anglecmpoverfrequency)

--- a/tests/test_anglecmpoverfrequency/test_anglecmpoverfrequency.h
+++ b/tests/test_anglecmpoverfrequency/test_anglecmpoverfrequency.h
@@ -1,0 +1,16 @@
+#ifndef TEST_ANGLECMPOVERFREQUENCY
+#define TEST_ANGLECMPOVERFREQUENCY
+
+#include <QTest>
+#include "anglecmpoverfrequency.h"
+
+class test_anglecmpoverfrequency : public QObject
+{
+	Q_OBJECT
+private slots:
+    void test_getcompValue();
+    void test_frequencyRange();
+    void test_angleCorrection();
+};
+
+#endif

--- a/tests/test_anglecmpoverfrequency/test_anglecmpoverfrequency.pro
+++ b/tests/test_anglecmpoverfrequency/test_anglecmpoverfrequency.pro
@@ -1,0 +1,19 @@
+QT += testlib qt3support
+
+CONFIG += qt console warn_on depend_includepath testcase
+CONFIG -= app_bundle
+
+TEMPLATE = app
+
+HEADERS = \
+    test_anglecmpoverfrequency.h
+
+SOURCES = \
+    test_anglecmpoverfrequency.cpp
+
+INCLUDEPATH += \
+    ../../wm-common/settings \
+    ../../wm-common/dsp \
+    ../../wm-common
+
+LIBS += -L../../wm-common -lwm-common

--- a/tests/tests.pro
+++ b/tests/tests.pro
@@ -6,4 +6,5 @@ SUBDIRS = \
     test_settingschangetimer \
     test_sessionfilenamegen \
     test_phasejusthelper \
+    test_anglecmpoverfrequency \
     test_sessionstreamer

--- a/wm-common/settings/anglecmpoverfrequency.cpp
+++ b/wm-common/settings/anglecmpoverfrequency.cpp
@@ -1,0 +1,63 @@
+#include "anglecmpoverfrequency.h"
+
+angleCmpOverFrequency::angleCmpOverFrequency()
+{
+
+}
+
+angleCmpOverFrequency::angleCmpOverFrequency(cConfData *confData, cwmActValues *actValues)
+{
+    getCompValue(getSampleRate(confData->m_nSRate) ,confData->m_fSFreq);
+    if (isFreuqencyInRange(actValues->Frequenz)){
+        correctAngle(1.0,actValues->Frequenz,confData->m_fSFreq);
+    }
+}
+
+double angleCmpOverFrequency::getCompValue(int sampleRate, int confFrequency)
+{
+    double val (0.0);
+    if (sampleRate == 80) {
+        if (confFrequency == 50)
+            val = samp80Freq50;
+        if (confFrequency == 60)
+            val = samp80Freq60;
+    }
+    if (sampleRate == 256) {
+        if (confFrequency == 50)
+            val = samp256Freq50;
+        if (confFrequency == 60)
+            val = samp256Freq60;
+    }
+    m_angleCorrectionFactor = val;
+    return val;
+}
+
+bool angleCmpOverFrequency::isFreuqencyInRange(double frequency)
+{
+    bool ok(false);
+    if ((frequency > 15.0) && (frequency < 65.0))
+        ok = true;
+    return ok;
+}
+
+double angleCmpOverFrequency::correctAngle(double Angle, double actualFrequency, double confFrequency)
+{
+    double corrAngle;
+    double diffFrequency;
+    diffFrequency = actualFrequency - confFrequency;
+    double corrVal = diffFrequency * m_angleCorrectionFactor;
+    corrAngle = Angle + corrVal;
+    m_angleCorrectionValue = corrVal;
+    return corrAngle;
+}
+
+double angleCmpOverFrequency::getAngleCorrectionValue()
+{
+    return m_angleCorrectionValue;
+}
+
+int angleCmpOverFrequency::getSampleRate(int sr)
+{  // don't repeat yourselve!
+    int SRates[5]={80,96,240,256,288};
+    return SRates[sr];
+}

--- a/wm-common/settings/anglecmpoverfrequency.cpp
+++ b/wm-common/settings/anglecmpoverfrequency.cpp
@@ -17,12 +17,16 @@ double angleCmpOverFrequency::getCompValue(int sampleRate, int confFrequency)
 {
     double val (0.0);
     if (sampleRate == 80) {
+        if (confFrequency == 16)
+            val = samp80Freq1623;
         if (confFrequency == 50)
             val = samp80Freq50;
         if (confFrequency == 60)
             val = samp80Freq60;
     }
     if (sampleRate == 256) {
+        if (confFrequency == 16)
+            val = samp256Freq1623;
         if (confFrequency == 50)
             val = samp256Freq50;
         if (confFrequency == 60)

--- a/wm-common/settings/anglecmpoverfrequency.h
+++ b/wm-common/settings/anglecmpoverfrequency.h
@@ -1,0 +1,39 @@
+#ifndef ANGLECMPOVERFREQUENCY_H
+#define ANGLECMPOVERFREQUENCY_H
+
+#include <QObject>
+#include <math.h>
+#include "confdata.h"
+#include "wmactvalues.h"
+
+/*
+ * WM3000I and WM3000U
+ * 80 Samples/Per. 50Hz à 0,656°/Hz
+ * 80 Samples/Per. 60Hz à 0,546°/Hz
+ * 256 Samples/Per. 50Hz à 0,789°/Hz
+ * 256 Samples/Per. 60Hz à 0,649°/Hz
+ */
+
+const double samp80Freq50 = 0.656 / 180 * M_PI;
+const double samp80Freq60 = 0.546 / 180 * M_PI;
+const double samp256Freq50 = 0.789 / 180 * M_PI;
+const double samp256Freq60 = 0.649 / 180 * M_PI;
+
+class angleCmpOverFrequency : public QObject
+{
+    Q_OBJECT
+public:
+    angleCmpOverFrequency();
+    angleCmpOverFrequency(cConfData *confData, cwmActValues *actValues);
+    double getCompValue(int sampleRate, int confFrequency);
+    bool isFreuqencyInRange(double frequency);
+    double correctAngle(double Angle, double actualFrequency, double confFrequency);
+    double getAngleCorrectionValue();
+private:
+    double m_angleCorrectionFactor;
+    double m_angleCorrectionValue;
+
+    int getSampleRate(int sr);
+};
+
+#endif // ANGLECMPOVERFREQUENCY_H

--- a/wm-common/settings/anglecmpoverfrequency.h
+++ b/wm-common/settings/anglecmpoverfrequency.h
@@ -18,6 +18,8 @@ const double samp80Freq50 = 0.656 / 180 * M_PI;
 const double samp80Freq60 = 0.546 / 180 * M_PI;
 const double samp256Freq50 = 0.789 / 180 * M_PI;
 const double samp256Freq60 = 0.649 / 180 * M_PI;
+const double samp80Freq1623 = 1.965 / 180 * M_PI;
+const double samp256Freq1623 = 2.3305 / 180 * M_PI;
 
 class angleCmpOverFrequency : public QObject
 {

--- a/wm-common/settings/confdata.h
+++ b/wm-common/settings/confdata.h
@@ -5,7 +5,6 @@
 #ifndef CONFDATA_H
 #define CONFDATA_H
 
-#include <q3ptrlist.h>
 #include <qstring.h>
 
 #include "ethadress.h"

--- a/wm-common/wm-common.pro
+++ b/wm-common/wm-common.pro
@@ -61,6 +61,7 @@ HEADERS = \
     scpi/scpistatsyst.h \
     scpi/wm3000scpiface.h \
     scpi/wm3kscpispecialbase.h \
+    settings/anglecmpoverfrequency.h \
     settings/confdata.h \
     settings/ethadress.h \
     settings/settingschangetimer.h \
@@ -130,6 +131,7 @@ SOURCES = \
     scpi/scpiface.cpp \
     scpi/scpistatsyst.cpp \
     scpi/wm3000scpiface.cpp \
+    settings/anglecmpoverfrequency.cpp \
     settings/confdata.cpp \
     settings/ethadress.cpp \
     settings/settingschangetimer.cpp \

--- a/wm3000u/wm3000u.cpp
+++ b/wm3000u/wm3000u.cpp
@@ -34,6 +34,7 @@
 #include "scpioperationstates.h"
 #include "scpiquestionstates.h"
 #include "wmmessagebox.h"
+#include "anglecmpoverfrequency.h"
 
 extern WMViewBase *g_WMView;
 char* MModeName[maxMMode] = {(char*)"Un/Ux",(char*)"Un/EVT",(char*)"Un/nConvent"};
@@ -4240,6 +4241,16 @@ void cWM3000U::CmpActValues() {  // here we will do all the necessary computatio
     double phik;
     //  korrektur des kanal X vektors mit der abtastverzögerung und dem bekannten phasenfehler des prüflings
     phik = ( ( -360.0  * ActValues.Frequenz * m_ConfData.m_fxTimeShift * 1.0e-3 ) - m_ConfData.m_fxPhaseShift) * PI_180;
+
+    // This is the 2023 Version of the next level correction, only in non conventional mode, the angle error shall be corrected by
+    // a certain value dependent of the rated sample rate and the rated frequency (aka samplerate).
+
+    if ( m_ConfData.m_nMeasMode == Un_nConvent)  // nur nConvent
+    {
+        angleCmpOverFrequency angleComp(&m_ConfData, &ActValues);
+        phik += angleComp.getAngleCorrectionValue();
+    }
+
     ActValues.VekXSek *= complex( cos(phik),sin(phik) );
 
     // eigenfehler korrektur des normwandlers


### PR DESCRIPTION
This is issue 777 from the EW list
The compensation is done between 15 and 65 Hz as this is the rated freq. The difference between the configured frequency and the measured is taken into account and the different values for the configured sample rates and configured frequencies